### PR TITLE
Support ES6 required Content-Type header

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,17 @@ Usage
 * Create the Index:
 
 ```
-curl -XPUT 'http://localhost:9200/comicbook/' -d '{
-    "settings" : {
-        "index" : {
-            "number_of_shards" : 3,
-            "number_of_replicas" : 1
-        }
-    }
-}'
+curl -H 'Content-Type: application/json' \
+  -X PUT \
+  -d '{
+      "settings" : {
+          "index" : {
+              "number_of_shards" : 3,
+              "number_of_replicas" : 1
+          }
+      }
+  }' \
+  http://localhost:9200/comicbook/
 ```
 
 * From command line, execute the script:

--- a/elasticput.php
+++ b/elasticput.php
@@ -32,6 +32,7 @@ if (($handle = fopen('indexme.csv', "r")) !== FALSE) {
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_FORBID_REUSE, 0);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-type: application/json'));
         curl_setopt($ch, CURLOPT_POSTFIELDS, $jsonData);
         $response = curl_exec($ch);
         echo 'RESPONSE: ' . $response . "\n\n";


### PR DESCRIPTION
Modify cURL requests to include

```
Content-Type: application/json
```

_Background_: Starting from Elasticsearch 6.0, all REST requests that include a body
must also provide the correct content-type for that body.

https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests